### PR TITLE
update verifiedboot patch and disable dm-verity

### DIFF
--- a/drivers/md/dm-android-verity.c
+++ b/drivers/md/dm-android-verity.c
@@ -369,6 +369,8 @@ static int verify_header(struct android_metadata_header *header)
 {
 	int retval = -EINVAL;
 
+	return VERITY_STATE_DISABLE;
+
 	if (is_userdebug() && le32_to_cpu(header->magic_number) ==
 			VERITY_METADATA_MAGIC_DISABLE)
 		return VERITY_STATE_DISABLE;

--- a/fs/proc/cmdline.c
+++ b/fs/proc/cmdline.c
@@ -2,13 +2,10 @@
 #include <linux/init.h>
 #include <linux/proc_fs.h>
 #include <linux/seq_file.h>
-#include <asm/setup.h>
-
-static char new_command_line[COMMAND_LINE_SIZE];
 
 static int cmdline_proc_show(struct seq_file *m, void *v)
 {
-	seq_printf(m, "%s\n", new_command_line);
+	seq_printf(m, "%s\n", saved_command_line);
 	return 0;
 }
 
@@ -26,29 +23,6 @@ static const struct file_operations cmdline_proc_fops = {
 
 static int __init proc_cmdline_init(void)
 {
-	char *offset_addr, *cmd = new_command_line;
-
-	strcpy(cmd, saved_command_line);
-
-	/*
-	 * Remove 'androidboot.verifiedbootstate' flag from command line seen
-	 * by userspace in order to pass SafetyNet CTS check.
-	 */
-	offset_addr = strstr(cmd, "androidboot.verifiedbootstate=");
-	if (offset_addr) {
-		size_t i, len, offset;
-
-		len = strlen(cmd);
-		offset = offset_addr - cmd;
-
-		for (i = 1; i < (len - offset); i++) {
-			if (cmd[offset + i] == ' ')
-				break;
-		}
-
-		memmove(offset_addr, &cmd[offset + i + 1], len - i - offset);
-	}
-
 	proc_create("cmdline", 0, NULL, &cmdline_proc_fops);
 	return 0;
 }

--- a/fs/proc/cmdline.c
+++ b/fs/proc/cmdline.c
@@ -2,10 +2,13 @@
 #include <linux/init.h>
 #include <linux/proc_fs.h>
 #include <linux/seq_file.h>
+#include <asm/setup.h>
+
+static char proc_cmdline[COMMAND_LINE_SIZE];
 
 static int cmdline_proc_show(struct seq_file *m, void *v)
 {
-	seq_printf(m, "%s\n", saved_command_line);
+	seq_printf(m, "%s\n", proc_cmdline);
 	return 0;
 }
 
@@ -23,6 +26,23 @@ static const struct file_operations cmdline_proc_fops = {
 
 static int __init proc_cmdline_init(void)
 {
+	/* SafetyNet bypass: show androidboot.verifiedbootstate=green */
+	char *a1, *a2;
+
+	a1 = strstr(saved_command_line, "androidboot.verifiedbootstate=");
+	if (a1) {
+		a1 = strchr(a1, '=');
+		a2 = strchr(a1, ' ');
+		if (!a2) /* last argument on the cmdline */
+			a2 = "";
+
+		scnprintf(proc_cmdline, COMMAND_LINE_SIZE, "%.*sgreen%s",
+			  (int)(a1 - saved_command_line + 1),
+			  saved_command_line, a2);
+	} else {
+		strncpy(proc_cmdline, saved_command_line, COMMAND_LINE_SIZE);
+	}
+
 	proc_create("cmdline", 0, NULL, &cmdline_proc_fops);
 	return 0;
 }


### PR DESCRIPTION
Instead of just removing the verified boot flag from cmdline, the new patch forces it to be "green" all the time.

The dm-verity patch is whats needed on AOSP ROMs to allow installing GApps properly.
Without that patch, dm-verity kills the GApps on boot.

I'm not sure if that is something that should be going into the stock kernel, as it basically is killing a security feature, but thats up to you.